### PR TITLE
Small fixes

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -125,9 +125,9 @@ async fn run_async(event_loop: EventLoop<()>, window: winit::window::Window) {
     let winit::dpi::PhysicalSize { width: win_w, height: win_h } = window.inner_size();
     let win_center_x = win_w / 2;
     let win_center_y = win_h / 2;
-    window.set_cursor_position(winit::dpi::LogicalPosition::new(
-        win_center_x, win_center_y,
-    )).expect("set cursor position");
+    let _ignore_error = window
+        .set_cursor_position(winit::dpi::LogicalPosition::new(win_center_x, win_center_y))
+        .map_err(|_| eprintln!("unable to set cursor position"));
     window.set_maximized(true);
 
     let mut player_rot_x: f32 = 0.0;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# edition = "2018"
+disable

--- a/src/mesh/mesh_pass.rs
+++ b/src/mesh/mesh_pass.rs
@@ -107,7 +107,7 @@ impl MeshPass {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: DEPTH_FORMAT,
+            format: sc_desc.format,
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
         });
 


### PR DESCRIPTION
My window manager didn't allow the basic example to set the cursor position, so I stopped it from panicking there.

The bloom texture used two different formats, causing it to crash. I assume it should be `sc_desc.format` in both cases as using `DEPTH_FORMAT` in both still crashed.

I added a rustfmt.toml that's invalid so that editors won't auto-format. I can instead format everything if you give me settings to use (or to just use the defaults).